### PR TITLE
Fix and add CI job for packaging 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,5 +80,9 @@ jobs:
           python -m build
       - uses: actions/upload-artifact@v3
         with:
-          name: build-output
-          path: dist/
+          name: source_dist
+          path: dist/*.tar.gz
+      - uses: actions/upload-artifact@v3
+        with:
+          name: built_dist
+          path: dist/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,22 @@ jobs:
         with:
           name: built_dist
           path: dist/*.whl
-      - name: Check wheel contents
+  
+  check-wheel:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: built_dist
+          path: wheel.whl
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install check_wheel_contents
         run: |
-          python -m check_wheel_contents dist/*.whl
+          pip install check_wheel_contents
+      - name: Run check_wheel_contents
+        run: |
+          python -m check_wheel_contents wheel.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,3 +86,6 @@ jobs:
         with:
           name: built_dist
           path: dist/*.whl
+      - name: Check wheel contents
+        run: |
+          python -m check_wheel_contents dist/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,3 +78,7 @@ jobs:
       - name: Run build
         run: |
           python -m build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build-output
+          path: dist/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,3 +63,18 @@ jobs:
       - name: Run pylint with pylint_flask_sqlalchemy
         run: |
           pylint --load-plugins pylint_flask_sqlalchemy *.py
+  
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install build
+        run: |
+          pip install build
+      - name: Run build
+        run: |
+          python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "astroid", "check_wheel_contents"]
+requires = ["setuptools", "wheel", "astroid"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "astroid"]
+requires = ["setuptools", "wheel", "astroid", "check_wheel_contents"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 
 [options]
 zip_safe = false
+packages = pylint_flask_sqlalchemy
 include_package_data = true
 python_requires = >= 3.6
 install_requires = 


### PR DESCRIPTION
When trying to use this plugin, I found a few issues that this PR resolves:

# TLDR:

I fixed two things and added two CI jobs to make your life easier. See https://github.com/iFreilicht/pylint_flask_sqlalchemy/actions/runs/2028803993

You can also download the built wheel and tar.gz distributions there.

# Issues

## 1. The `tests` directory is installed as an additional package, breaking linting on all my tests

After installing this plugin, the errors relating to `flask_sqlalchemy` were fixed, but I got a new issue:

```
$ python3.8 -m pylint -E modules tests tools updater
************* Module tests
tests/__init__.py:1:0: F0010: error while code parsing: Unable to load file tests/__init__.py:
[Errno 2] No such file or directory: 'tests/__init__.py' (parse-error)
************* Module a_special_tool
tools/a_special_tool/a_special_tool.py:23:0: E0611: No name 'test_special_tool' in module 'tests' (no-name-in-module)
tools/a_special_tool/a_special_tool.py:23:0: E0401: Unable to import 'tests.test_special_tool' (import-error)
```

The reason for these is that `pylint_flask_sqlalchemy` actually installs two packages:

```
$ pip uninstall pylint_flask_sqlalchemy
Found existing installation: pylint-flask-sqlalchemy 0.2.0
Uninstalling pylint-flask-sqlalchemy-0.2.0:
  Would remove:
    /home/<long-path>/.venv/lib/python3.8/site-packages/pylint_flask_sqlalchemy-0.2.0.dist-info/*
    /home/<long-path>/.venv/lib/python3.8/site-packages/pylint_flask_sqlalchemy/*
    /home/<long-path>/.venv/lib/python3.8/site-packages/tests/*
Proceed (Y/n)? n
```

Because tests is now an installed package in my venv, python will consider it first when searching for the `tests` module during import, meaning [pylint tries to lint that, but fails](https://github.com/PyCQA/pylint/issues/3528#issuecomment-727642370).

## 2. Building a wheel with `build` builds an empty wheel

Because there was no build process documented but I saw a `pyproject.toml`, I thought I could use `build` to debug the issue myself. As it turns out, that builds an empty wheel:

```
$ python -m build
# Lots of output, but this seemed to work fine
$ python -m check_wheel_contents dist/*.whl
dist/pylint_flask_sqlalchemy-1.0.0rc0-py3-none-any.whl: W007: Wheel library is empty
dist/pylint_flask_sqlalchemy-1.0.0rc0-py3-none-any.whl: W008: Wheel is empty
```

## 3. No CI job for building

This is not really an issue per se, but it might help you get started with the distribution job you mention in #13. As an additonal resource, [this github actions config](https://github.com/4DNucleome/PartSegCore-compiled-backend/actions/runs/323676826/workflow#L95) should help you out.

# Fix explanation

This was fixed by explicitly setting `packages = pylint_flask_sqlalchemy` in `setup.cfg`. After downloading the built wheel from [the finished github workflow](https://github.com/iFreilicht/pylint_flask_sqlalchemy/actions/runs/2028803993) or installing directly through git, you can see the difference:

```
$ pip install git+https://github.com/iFreilicht/pylint_flask_sqlalchemy.git@master
# Lots of output
$ pip uninstall pylint_flask_sqlalchemy
Found existing installation: pylint-flask-sqlalchemy 1.0.0rc0
Uninstalling pylint-flask-sqlalchemy-1.0.0rc0:
  Would remove:
    /home/felix/NavVis/epicshelter/.venv/lib/python3.8/site-packages/pylint_flask_sqlalchemy-1.0.0rc0.dist-info/*
    /home/felix/NavVis/epicshelter/.venv/lib/python3.8/site-packages/pylint_flask_sqlalchemy/*
Proceed (Y/n)?
```

I also added a job to the CI pipeline to check for empty wheels the way I did to avoid a potential future regression.